### PR TITLE
Update sample_13TeV_25ns.json

### DIFF
--- a/DMAnalysis/data/sample_13TeV_25ns.json
+++ b/DMAnalysis/data/sample_13TeV_25ns.json
@@ -53,6 +53,31 @@
     },
     {
       "isdata": false,
+      "color": "845",
+      "lcolor": "1",
+      "tag": "ggToZZ#rightarrow 2l2#nu",
+      "marker": 842,
+      "data": [
+        {
+          "dtag": "MC13TeV_GluGluToZZTo2e2nu",
+          "xsec": 0.00172,
+          "split": 1,
+          "br": [
+            1
+          ]
+        },
+        {
+          "dtag": "MC13TeV_GluGluToZZTo2mu2nu",
+          "xsec": 0.00172,
+          "split": 1,
+          "br": [
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "isdata": false,
       "color": "832",
       "lcolor": "1",
       "tag": "VVV",
@@ -94,6 +119,54 @@
           "dtag": "MC13TeV_ZZTo2L2Q",
           "xsec": 3.22,
           "split": 10,
+          "br": [
+            1
+          ]
+        },
+        {
+          "dtag": "MC13TeV_ggToZZTo2e2mu",
+          "xsec": 0.00319,
+          "split": 1,
+          "br": [
+            1
+          ]
+        },
+        {
+          "dtag": "MC13TeV_GluGluToZZTo2mu2tau",
+          "xsec": 0.00319,
+          "split": 1,
+          "br": [
+            1
+          ]
+        },
+        {
+          "dtag": "MC13TeV_ggToZZTo2e2tau",
+          "xsec": 0.00319,
+          "split": 1,
+          "br": [
+            1
+          ]
+        },
+        {
+          "dtag": "MC13TeV_GluGluToZZTo4e",
+          "xsec": 0.001586,
+          "split": 1,
+          "br": [
+            1
+          ]
+        },
+        {
+          "dtag": "MC13TeV_GluGluToZZTo4mu",
+          "xsec": 0.001586,
+          "split": 1,
+          "br": [
+            1
+          ]
+        },
+        {
+          "dtag": "MC13TeV_GluGluToZZTo4tau",
+          "xsec": 0.001586,
+          "split": 1,
           "br": [
             1
           ]

--- a/DMAnalysis/data/sample_13TeV_25ns.json
+++ b/DMAnalysis/data/sample_13TeV_25ns.json
@@ -124,7 +124,7 @@
           ]
         },
         {
-          "dtag": "MC13TeV_ggToZZTo2e2mu",
+          "dtag": "MC13TeV_GluGluToZZTo2e2mu",
           "xsec": 0.00319,
           "split": 1,
           "br": [
@@ -140,7 +140,7 @@
           ]
         },
         {
-          "dtag": "MC13TeV_ggToZZTo2e2tau",
+          "dtag": "MC13TeV_GluGluToZZTo2e2tau",
           "xsec": 0.00319,
           "split": 1,
           "br": [


### PR DESCRIPTION
adding GluGluZZ samples and also modifying the dtag for them to be compatible with skimlist output to avoid any problem in merging 

https://docs.google.com/spreadsheets/d/1iPdZEm_jpvOnFchXasV3lJo2Oe1yYvSLUD7FSRD6KjI/edit#gid=1594342584
https://cmsweb.cern.ch/das/request?view=list&limit=150&instance=prod%2Fglobal&input=dataset%3D%2FGluGluToContinToZZTo*_13TeV_MCFM701_pythia8%2FRunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1%2FMINIAODSIM
